### PR TITLE
Fix to makedist.py work on *nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 sedona*.jar
 temp
 manifests
+doc
+stage
+version.txt
+svm

--- a/adm/makedist.py
+++ b/adm/makedist.py
@@ -23,6 +23,7 @@ import fileutil
 import makesedona
 import makesedonac
 import makewinvm
+import makeunixvm
 import compilekit
 
 # exact copies; tuple is (dirName, exclude regex)
@@ -83,8 +84,11 @@ def compile():
   # make docs
   compilekit.compile(os.path.join(env.doc, "toc.xml"))
 
-  # make windows svm
-  makewinvm.compile()
+  # Make Sedona VM (svm)
+  if os.name == "posix": # unix, OSX
+    makeunixvm.main([])
+  else: # win32
+    makewinvm.compile()
 
 ################################################################
 # Stage


### PR DESCRIPTION
A quick fix to create a distribution on Linux. Tested on CentOS 6.6 32-bit and it generates sedona-1.2.29.zip with kits and docs correctly.