### PR TITLE
simple web server support for static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ sedona-*.zip
 *.log
 *.swo
 .DS_Store
+statics/*

--- a/apps/webServer.sax
+++ b/apps/webServer.sax
@@ -1,0 +1,88 @@
+<?xml version='1.0'?>
+<sedonaApp>
+<schema>
+  <kit name="sys" />
+  <kit name="basicSchedule" />
+  <kit name="communityWebServer" />
+  <kit name="datetime" />
+  <kit name="datetimeStd" />
+  <kit name="func" />
+  <kit name="hvac" />
+  <kit name="inet" />
+  <kit name="logic" />
+  <kit name="math" />
+  <kit name="platUnix" />
+  <kit name="pstore" />
+  <kit name="sox" />
+  <kit name="timing" />
+  <kit name="types" />
+  <kit name="web" />
+</schema>
+<app>
+  <prop name="appName" val="demo"/>
+  <!-- /service -->
+  <comp name="service" id="1" type="sys::Folder">
+    <prop name="meta" val="33685505"/>
+    <!-- /service/plat -->
+    <comp name="plat" id="9" type="platUnix::UnixPlatformService">
+      <prop name="meta" val="17629185"/>
+    </comp>
+    <!-- /service/users -->
+    <comp name="users" id="3" type="sys::UserService">
+      <prop name="meta" val="16842753"/>
+      <!-- /service/users/admin -->
+      <comp name="admin" id="4" type="sys::User">
+        <prop name="cred" val="hE49ksThgAeLkWB3NUU1NWeDO54="/>
+        <prop name="perm" val="2147483647"/>
+        <prop name="prov" val="255"/>
+      </comp>
+    </comp>
+    <!-- /service/sox -->
+    <comp name="sox" id="5" type="sox::SoxService">
+      <prop name="meta" val="17104897"/>
+    </comp>
+    <!-- /service/web -->
+    <comp name="web" id="6" type="web::WebService">
+      <prop name="meta" val="17367041"/>
+      <prop name="port" val="8080"/>
+      <!-- /service/WebServ/StaticF -->
+      <comp name="StaticF" id="14" type="communityWebServer::StaticFileWeblet">
+        <prop name="meta" val="33685505"/>
+        <prop name="urlPrefix" val="doc"/>
+      </comp>
+    </comp>
+    <!-- /service/pstore -->
+    <comp name="pstore" id="11" type="pstore::PstoreService">
+      <prop name="meta" val="17956865"/>
+    </comp>
+    <!-- /service/time -->
+    <comp name="time" id="12" type="datetimeStd::DateTimeServiceStd">
+      <prop name="meta" val="18284545"/>
+      <prop name="utcOffset" val="32400"/>
+      <prop name="osUtcOffset" val="true"/>
+    </comp>
+  </comp>
+  <!-- /play -->
+  <comp name="play" id="10" type="sys::Folder">
+    <prop name="meta" val="34013185"/>
+    <!-- /play/rampA -->
+    <comp name="rampA" id="7" type="func::Ramp">
+      <prop name="meta" val="67371009"/>
+      <prop name="min" val="20.0"/>
+      <prop name="max" val="80.0"/>
+    </comp>
+    <!-- /play/rampB -->
+    <comp name="rampB" id="8" type="func::Ramp">
+      <prop name="meta" val="68288513"/>
+    </comp>
+    <!-- /play/adder -->
+    <comp name="adder" id="2" type="math::Add2">
+      <prop name="meta" val="386662401"/>
+    </comp>
+  </comp>
+</app>
+<links>
+  <link from="/play/rampA.out" to="/play/adder.in1"/>
+  <link from="/play/rampB.out" to="/play/adder.in2"/>
+</links>
+</sedonaApp>

--- a/scode/webServer.xml
+++ b/scode/webServer.xml
@@ -1,0 +1,39 @@
+<!--
+  -  Sedona SCode manifest for a generic unix platform
+  -->
+
+<sedonaCode
+   endian="little"
+   blockSize="4"
+   refSize="4"
+   main="sys::Sys.main"
+   debug="true"
+   test="true"
+>
+
+  <!-- Kits -->
+  <depend on="sys 1.2" />
+  <depend on="sox 1.2" />
+  <depend on="inet 1.2" />
+  <depend on="web 1.2" />
+  <depend on="communityWebServer 1.2" />
+
+  <!-- Deprecated as of 1.2
+  <depend on="control 1.0" />
+  -->
+  <depend on="pstore 1.2" />
+  <depend on="datetime 1.2" />
+  <depend on="datetimeStd 1.2" />
+  <depend on="basicSchedule 1.2" />
+  <depend on="platUnix 1.2" />
+
+  <!-- These replace control kit as of 1.2 -->
+  <depend on="func 1.2"    />
+  <depend on="hvac 1.2"    />
+  <depend on="logic 1.2"   />
+  <depend on="math 1.2"    />
+  <depend on="timing 1.2"  />
+  <depend on="types 1.2"   />
+
+</sedonaCode>
+

--- a/src/kits/communityWebServer/StaticFileWeblet.sedona
+++ b/src/kits/communityWebServer/StaticFileWeblet.sedona
@@ -9,22 +9,35 @@
 ** 
 ** StaticFileWeblet provides the ability to serve static files(html, css, js,
 ** images etc) through http, so that user can use sedona as a minimal web
-** server and host a static web app just in sedona, without any outside
-** dependency. 
-** to save space on sedona, gzipped file is supported and I recommend to use it
+** server and host a static web app(SPA for example) just in sedona, without 
+** any outside dependency. 
+**
+** To enable this weblet, you need to create an object of this component as a 
+** child of WebService. Deleting the object will disable the weblet. This is
+** different comparing to SpyWeblet. 
+**
+** You can create multiple objects of StaticFileWeblet and every object uses
+** different urlPrefix, so that sedona is possible to host multiple web apps.
+**
+** To save space on sedona, gzipped file is supported and I recommend to use it
 ** since that will be more efficient(less bytes to be loaded and transferred)
 ** 
 class StaticFileWeblet extends Weblet
 {
+  @config @asStr property Buf(12) urlPrefix = "statics"
 ////////////////////////////////////////////////////////////////
 // Weblet Registration
 ////////////////////////////////////////////////////////////////
 
-  static void _sInit()
+  override void start() 
   {
-    instance.register()
+    register()
   }
-  static internal inline StaticFileWeblet instance
+
+  override void stop()
+  {
+    unregister()
+  }
 
 ////////////////////////////////////////////////////////////////
 // Weblet
@@ -32,9 +45,10 @@ class StaticFileWeblet extends Weblet
 
   ** 
   ** all static files to be served must be put under 'statics' folder
-  ** and the url will start with 'statics', too 
+  ** and the url will start with 'statics', too. If you want to use other
+  ** name, config it by urlPrefix slot, Note: the max length is 11 chars
   **
-  override Str prefix() { return "statics" }
+  override Str prefix() { return urlPrefix.toStr() }
 
   override Str description() { return "Sedona Static File Weblet" }
 

--- a/src/kits/communityWebServer/StaticFileWeblet.sedona
+++ b/src/kits/communityWebServer/StaticFileWeblet.sedona
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2018
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   30 Jun 18  Vincent Wang  Static File Weblet
+//
+
+** 
+** StaticFileWeblet provides the ability to serve static files(html, css, js,
+** images etc), so that user can use sedona as a minimal web server and host 
+** a static web app just in sedona, without any outside dependency
+** 
+class StaticFileWeblet extends Weblet
+{
+////////////////////////////////////////////////////////////////
+// Weblet Registration
+////////////////////////////////////////////////////////////////
+
+  static void _sInit()
+  {
+    instance.register()
+  }
+  static internal inline StaticFileWeblet instance
+
+////////////////////////////////////////////////////////////////
+// Weblet
+////////////////////////////////////////////////////////////////
+
+  override Str prefix() { return "statics" }
+
+  override Str description() { return "Sedona Static File Weblet" }
+
+  override void service(WebReq req, WebRes res)
+  {
+    Str method = req.method;
+    if (method.equals("GET")) 
+      get(req, res)
+    else {
+      res.writeStatus(HttpCode.methodNotAllowed)
+      res.writeHeader("Allow", "GET")
+    }
+  }
+
+  override void get(WebReq req, WebRes res)
+  {
+    // route to static file
+    Str p = ""
+    if (req.path.size > 1) p = req.path.names[1]
+
+    index(req, res)
+  }
+
+////////////////////////////////////////////////////////////////
+// functions
+////////////////////////////////////////////////////////////////
+
+  public void index(WebReq req, WebRes res)
+  {
+    res.html();
+    res.w("<h1>Hello World!</h1>\n");
+    res.htmlEnd();
+  }
+
+}
+

--- a/src/kits/communityWebServer/StaticFileWeblet.sedona
+++ b/src/kits/communityWebServer/StaticFileWeblet.sedona
@@ -57,9 +57,22 @@ class StaticFileWeblet extends Weblet
 
   internal void serveFile(WebRes res) 
   {
-    if (file.name==null || !file.exists()) {
+    if (file.name==null) {
       res.writeStatus(HttpCode.notFound).finishHeaders()
       return
+    }
+
+    if (!file.exists()) {
+      //try gzipped content
+      int index = file.name.length()
+      file.name.set(index++, '.')
+      file.name.set(index++, 'g')
+      file.name.set(index++, 'z')
+      file.name.set(index, 0)
+      if (!file.exists()) {
+        res.writeStatus(HttpCode.notFound).finishHeaders()
+        return
+      }
     }
 
     if (!file.open("r")) {
@@ -68,11 +81,12 @@ class StaticFileWeblet extends Weblet
     }
 
     App.log.message("Serving File: " + file.name);
-
     res.writeStatusOk()
 
     //write headers
-    //TODO: support Content-Encoding: gzip
+    if (endsWith(file.name, ".gz", 0))
+      res.writeHeader("Content-Encoding", "gzip");
+
     res.writeContentType(getContentType(file.name))
       .writeHeader("Cache-Control", "max-age=604800")
       .writeHeader("Server", "Sedona Web Server")
@@ -91,29 +105,33 @@ class StaticFileWeblet extends Weblet
     file.close()
   }
 
-  static public bool endsWith(Str str, Str suffix) {
-    return suffix.equalsRegion(str, str.length()-suffix.length(), str.length()+1)
+  static public bool endsWith(Str str, Str suffix, int endOffset) {
+    return suffix.equalsRegion(str, str.length()-suffix.length()-endOffset, str.length()-endOffset)
   } 
 
   internal Str getContentType(Str fileName) 
   {
-    if (endsWith(fileName, ".html"))  
+    int endOffset = 0
+    if (endsWith(fileName, ".gz", 0))
+      endOffset = 3
+
+    if (endsWith(fileName, ".html", endOffset) || endsWith(fileName, ".htm", endOffset))  
       return "text/html"
-    else if (endsWith(fileName, ".css"))
+    else if (endsWith(fileName, ".css", endOffset))
       return "text/css"
-    else if (endsWith(fileName, ".txt"))
+    else if (endsWith(fileName, ".txt", endOffset))
       return "text/plain"
-    else if (endsWith(fileName, ".js"))
+    else if (endsWith(fileName, ".js", endOffset))
       return "application/javascript"
-    else if (endsWith(fileName, ".json"))
+    else if (endsWith(fileName, ".json", endOffset))
       return "application/json"
-    else if (endsWith(fileName, ".xml"))
+    else if (endsWith(fileName, ".xml", endOffset))
       return "application/xml"
-    else if (endsWith(fileName, ".pdf"))
+    else if (endsWith(fileName, ".pdf", endOffset))
       return "application/pdf"
-    else if (endsWith(fileName, ".jpg"))
+    else if (endsWith(fileName, ".jpg", endOffset))
       return "image/jpeg"
-    else if (endsWith(fileName, ".png"))
+    else if (endsWith(fileName, ".png", endOffset))
       return "image/png"
     else
       return "text/plain"

--- a/src/kits/communityWebServer/StaticFileWeblet.sedona
+++ b/src/kits/communityWebServer/StaticFileWeblet.sedona
@@ -47,6 +47,20 @@ class StaticFileWeblet extends Weblet
     reset()
 
     prepareFile(req)
+
+    if (isDir(filePath)) {
+      //TODO: do http redirects
+      // if (!endsWith(filePath, "/", 0)) {
+      //   res.writeStatus(HttpCode.movedPermanently)
+      //     .w("Location").w(":").w(filePath).w("/")
+      //     .finishHeaders()
+      //     .finishHeaders()
+      //   return
+      // }
+
+      tryAppendIndex(filePath)
+    }
+
     serveFile(res)
   }
 
@@ -65,10 +79,13 @@ class StaticFileWeblet extends Weblet
     if (!file.exists()) {
       //try gzipped content
       int index = file.name.length()
-      file.name.set(index++, '.')
-      file.name.set(index++, 'g')
-      file.name.set(index++, 'z')
-      file.name.set(index, 0)
+      if (index+4 < pathStrLen) {
+        file.name.set(index++, '.')
+        file.name.set(index++, 'g')
+        file.name.set(index++, 'z')
+        file.name.set(index, 0)
+      }
+
       if (!file.exists()) {
         res.writeStatus(HttpCode.notFound).finishHeaders()
         return
@@ -105,6 +122,49 @@ class StaticFileWeblet extends Weblet
     file.close()
   }
 
+  bool isDir(Str fileName) {
+    if (endsWith(fileName, "/", 0))
+      return true
+
+    int len = fileName.length()
+    //check if there is a file extention 
+    for(int i=len-3; i>0 && i>len-6; --i) {
+      if (fileName.get(i) != '.')
+        continue
+
+      return false
+    }
+
+    return true
+  }
+
+  bool tryAppendIndex(Str fileName) {
+    int len = fileName.length()
+    if (len <= 0)
+      return false
+
+    //try to append index.html to path end 
+    byte[] buf = fileName.toBytes()
+    if (len+11 < pathStrLen) {
+      if (!endsWith(fileName, "/", 0))
+        buf[len++] = '/'
+      buf[len++] = 'i'
+      buf[len++] = 'n'
+      buf[len++] = 'd'
+      buf[len++] = 'e'
+      buf[len++] = 'x'
+      buf[len++] = '.'
+      buf[len++] = 'h'
+      buf[len++] = 't'
+      buf[len++] = 'm'
+      buf[len++] = 'l'
+      buf[len++] = 0 
+      return true
+    }
+
+    return false
+  }
+
   static public bool endsWith(Str str, Str suffix, int endOffset) {
     return suffix.equalsRegion(str, str.length()-suffix.length()-endOffset, str.length()-endOffset)
   } 
@@ -139,23 +199,23 @@ class StaticFileWeblet extends Weblet
 
   internal void prepareFile(WebReq req) 
   {
-    if (req.path.size <= 1)
+    if (req.path.size < 1)
       return
-    else if (req.path.size == 1)
-      filePath.copyFromStr("./index.html", pathStrLen)
     else {
+      //TODO: process path to avoid security issues
       filePath.copyFromStr(".", pathStrLen);
       int index = filePath.length()
       byte[] fileBuf = filePath.toBytes()
-      for(int i=0; i<req.path.size; ++i) {
+      for(int i=0; i<req.path.size && index<pathStrLen-2; ++i) {
         byte[] nameBuf = req.path.names[i].toBytes() 
         fileBuf[index++] = '/'
-        for(int j=0; j<req.path.names[i].length(); ++j) {
+        for(int j=0; j<req.path.names[i].length() && index<pathStrLen-2; ++j) {
           fileBuf[index++] = nameBuf[j]
         }
       }
       fileBuf[index] = 0
     }
+
     file.name = filePath
   }
 

--- a/src/kits/communityWebServer/StaticFileWeblet.sedona
+++ b/src/kits/communityWebServer/StaticFileWeblet.sedona
@@ -49,15 +49,6 @@ class StaticFileWeblet extends Weblet
     prepareFile(req)
 
     if (isDir(filePath)) {
-      //TODO: do http redirects
-      // if (!endsWith(filePath, "/", 0)) {
-      //   res.writeStatus(HttpCode.movedPermanently)
-      //     .w("Location").w(":").w(filePath).w("/")
-      //     .finishHeaders()
-      //     .finishHeaders()
-      //   return
-      // }
-
       tryAppendIndex(filePath)
     }
 

--- a/src/kits/communityWebServer/StaticFileWeblet.sedona
+++ b/src/kits/communityWebServer/StaticFileWeblet.sedona
@@ -44,15 +44,105 @@ class StaticFileWeblet extends Weblet
 
   override void get(WebReq req, WebRes res)
   {
-    // route to static file
-    Str p = ""
-    if (req.path.size > 1) p = req.path.names[1]
+    reset()
 
-    index(req, res)
+    prepareFile(req)
+    serveFile(res)
+  }
+
+  internal void reset() 
+  {
+    filePath.set(0, 0)
+  }
+
+  internal void serveFile(WebRes res) 
+  {
+    if (file.name==null || !file.exists()) {
+      res.writeStatus(HttpCode.notFound).finishHeaders()
+      return
+    }
+
+    if (!file.open("r")) {
+      res.writeStatus(HttpCode.internalError).finishHeaders()
+      return
+    }
+
+    App.log.message("Serving File: " + file.name);
+
+    res.writeStatusOk()
+
+    //write headers
+    //TODO: support Content-Encoding: gzip
+    res.writeContentType(getContentType(file.name))
+      .writeHeader("Cache-Control", "max-age=604800")
+      .writeHeader("Server", "Sedona Web Server")
+      .writeHeader("Content-Length", Sys.intStr(file.size()))
+      .finishHeaders()
+
+    file.seek(0)
+    while(true) {
+      int readed = file.in.readBytes(readBuf, 0, bufLen)
+      if (readed <= 0)
+        break
+
+      res.writeBytes(readBuf, 0, readed)
+    }
+
+    file.close()
+  }
+
+  static public bool endsWith(Str str, Str suffix) {
+    return suffix.equalsRegion(str, str.length()-suffix.length(), str.length()+1)
+  } 
+
+  internal Str getContentType(Str fileName) 
+  {
+    if (endsWith(fileName, ".html"))  
+      return "text/html"
+    else if (endsWith(fileName, ".css"))
+      return "text/css"
+    else if (endsWith(fileName, ".txt"))
+      return "text/plain"
+    else if (endsWith(fileName, ".js"))
+      return "application/javascript"
+    else if (endsWith(fileName, ".json"))
+      return "application/json"
+    else if (endsWith(fileName, ".xml"))
+      return "application/xml"
+    else if (endsWith(fileName, ".pdf"))
+      return "application/pdf"
+    else if (endsWith(fileName, ".jpg"))
+      return "image/jpeg"
+    else if (endsWith(fileName, ".png"))
+      return "image/png"
+    else
+      return "text/plain"
+  }
+
+  internal void prepareFile(WebReq req) 
+  {
+    if (req.path.size <= 1)
+      return
+    else if (req.path.size == 1)
+      filePath.copyFromStr("./index.html", pathStrLen)
+    else {
+      filePath.copyFromStr(".", pathStrLen);
+      int index = filePath.length()
+      byte[] fileBuf = filePath.toBytes()
+      for(int i=0; i<req.path.size; ++i) {
+        byte[] nameBuf = req.path.names[i].toBytes() 
+        fileBuf[index++] = '/'
+        for(int j=0; j<req.path.names[i].length(); ++j) {
+          fileBuf[index++] = nameBuf[j]
+        }
+      }
+      fileBuf[index] = 0
+    }
+    file.name = filePath
   }
 
 ////////////////////////////////////////////////////////////////
-// functions
+// Functions
 ////////////////////////////////////////////////////////////////
 
   public void index(WebReq req, WebRes res)
@@ -62,5 +152,14 @@ class StaticFileWeblet extends Weblet
     res.htmlEnd();
   }
 
+////////////////////////////////////////////////////////////////
+// Fields
+////////////////////////////////////////////////////////////////
+  define int bufLen = 1024
+  define int pathStrLen = 256
+
+  private inline byte[bufLen] readBuf
+  internal inline Str(pathStrLen) filePath  // buffer for file's path
+  internal inline File file
 }
 

--- a/src/kits/communityWebServer/StaticFileWeblet.sedona
+++ b/src/kits/communityWebServer/StaticFileWeblet.sedona
@@ -8,8 +8,11 @@
 
 ** 
 ** StaticFileWeblet provides the ability to serve static files(html, css, js,
-** images etc), so that user can use sedona as a minimal web server and host 
-** a static web app just in sedona, without any outside dependency
+** images etc) through http, so that user can use sedona as a minimal web
+** server and host a static web app just in sedona, without any outside
+** dependency. 
+** to save space on sedona, gzipped file is supported and I recommend to use it
+** since that will be more efficient(less bytes to be loaded and transferred)
 ** 
 class StaticFileWeblet extends Weblet
 {
@@ -27,10 +30,16 @@ class StaticFileWeblet extends Weblet
 // Weblet
 ////////////////////////////////////////////////////////////////
 
+  ** 
+  ** all static files to be served must be put under 'statics' folder
+  ** and the url will start with 'statics', too 
   override Str prefix() { return "statics" }
 
   override Str description() { return "Sedona Static File Weblet" }
 
+  **
+  ** since we only serve static file here, so only 'GET' method is supported
+  ** 
   override void service(WebReq req, WebRes res)
   {
     Str method = req.method;
@@ -42,6 +51,9 @@ class StaticFileWeblet extends Weblet
     }
   }
 
+  ** 
+  ** handle 'GET' request, try to find the static file and return it 
+  **
   override void get(WebReq req, WebRes res)
   {
     reset()
@@ -129,6 +141,9 @@ class StaticFileWeblet extends Weblet
     return true
   }
 
+  **
+  ** if the URL ends with '/', then append 'index.html' and try serve it 
+  **
   bool tryAppendIndex(Str fileName) {
     int len = fileName.length()
     if (len <= 0)

--- a/src/kits/communityWebServer/StaticFileWeblet.sedona
+++ b/src/kits/communityWebServer/StaticFileWeblet.sedona
@@ -33,6 +33,7 @@ class StaticFileWeblet extends Weblet
   ** 
   ** all static files to be served must be put under 'statics' folder
   ** and the url will start with 'statics', too 
+  **
   override Str prefix() { return "statics" }
 
   override Str description() { return "Sedona Static File Weblet" }
@@ -81,13 +82,7 @@ class StaticFileWeblet extends Weblet
 
     if (!file.exists()) {
       //try gzipped content
-      int index = file.name.length()
-      if (index+4 < pathStrLen) {
-        file.name.set(index++, '.')
-        file.name.set(index++, 'g')
-        file.name.set(index++, 'z')
-        file.name.set(index, 0)
-      }
+      appendStr(file.name, ".gz", pathStrLen)
 
       if (!file.exists()) {
         res.writeStatus(HttpCode.notFound).finishHeaders()
@@ -146,34 +141,49 @@ class StaticFileWeblet extends Weblet
   **
   bool tryAppendIndex(Str fileName) {
     int len = fileName.length()
-    if (len <= 0)
+    if (len <= 0 || len+1>=pathStrLen)
       return false
 
     //try to append index.html to path end 
-    byte[] buf = fileName.toBytes()
-    if (len+11 < pathStrLen) {
-      if (!endsWith(fileName, "/", 0))
-        buf[len++] = '/'
-      buf[len++] = 'i'
-      buf[len++] = 'n'
-      buf[len++] = 'd'
-      buf[len++] = 'e'
-      buf[len++] = 'x'
-      buf[len++] = '.'
-      buf[len++] = 'h'
-      buf[len++] = 't'
-      buf[len++] = 'm'
-      buf[len++] = 'l'
-      buf[len++] = 0 
-      return true
-    }
+    if (!endsWith(fileName, "/", 0))
+      appendStr(fileName, "/", pathStrLen)
 
-    return false
+    return appendStr(fileName, "index.html", pathStrLen)
   }
 
+  ** 
+  ** check if str ends with suffix.
+  ** if endOffset is not 0, then check the suffix after 
+  ** that offset. for example, to check if 'index.html.gz' 
+  ** ends with '.html': 
+  **   // buf equals "index.html.gz", offset is 3(len of ".gz")
+  **   endsWith(buf, ".html", 3)
+  **
   static public bool endsWith(Str str, Str suffix, int endOffset) {
     return suffix.equalsRegion(str, str.length()-suffix.length()-endOffset, str.length()-endOffset)
   } 
+
+  **
+  ** append suffix to the end of dst. 
+  ** return:
+  **   true if managed to append suffix to dst 
+  **   false if dst's buffer is not big enough
+  **
+  static public bool appendStr(Str dst, Str suffix, int bufMaxLen)
+  {
+    int dstLen = dst.length()
+    int suffixLen = suffix.length()
+    //return early if buffer is not big enough 
+    if (dstLen + suffixLen + 1 > bufMaxLen)
+      return false
+
+    byte[] dstBuf = dst.toBytes()
+    byte[] suffixBuf = suffix.toBytes()
+    for(int i=0; i<suffixLen; ++i) 
+      dstBuf[dstLen+i] = suffixBuf[i]
+    dstBuf[dstLen+suffixLen] = 0
+    return true
+  }
 
   internal Str getContentType(Str fileName) 
   {

--- a/src/kits/communityWebServer/kit.xml
+++ b/src/kits/communityWebServer/kit.xml
@@ -20,6 +20,7 @@
 
   <!-- Source Directories -->
   <source dir="." />
+  <source dir="test" />
 
 </sedonaKit>
 

--- a/src/kits/communityWebServer/kit.xml
+++ b/src/kits/communityWebServer/kit.xml
@@ -1,0 +1,25 @@
+<!--
+  -  Sedona Web Server Kit
+  -  Copyright (c) 2018 Sedona Community
+  -  Licensed under the Academic Free License version 3.0
+  -->
+
+<sedonaKit
+ name = "communityWebServer"
+ vendor = "community"
+ description = "Simple Web Server mainly to serve static files"
+ includeSource = "true"
+ doc = "true"
+>
+
+  <!-- Dependencies -->
+  <depend on="sys 1.2+" />
+  <depend on="inet 1.2+" />
+  <depend on="sox 1.2+" />
+  <depend on="web 1.2+" />
+
+  <!-- Source Directories -->
+  <source dir="." />
+
+</sedonaKit>
+

--- a/src/kits/communityWebServer/test/StrUtilTest.sedona
+++ b/src/kits/communityWebServer/test/StrUtilTest.sedona
@@ -1,0 +1,35 @@
+@palette=false
+public class StrUtilTest extends Test
+{
+  static void testEndsWith()
+  {
+    assert(!StaticFileWeblet.endsWith("/foo/bar", "/", 0))
+    assert(StaticFileWeblet.endsWith("/foo/bar/", "/", 0))
+    assert(StaticFileWeblet.endsWith("/foo/bar/index.html", ".html", 0))
+
+    assert(StaticFileWeblet.endsWith("/foo/bar/vue.min.js.gz", ".js", 3))
+  } 
+
+  static void testAppendStr()
+  {
+    assert(StaticFileWeblet.appendStr(buf, "/foo/bar", bufLen))
+    assert(buf.equals("/foo/bar"))
+
+    assert(StaticFileWeblet.appendStr(buf, "/", bufLen))
+    assert(buf.equals("/foo/bar/"))
+
+    assert(StaticFileWeblet.appendStr(buf, "index.html", bufLen))
+    assert(buf.equals("/foo/bar/index.html"))
+
+    assert(StaticFileWeblet.appendStr(buf, ".gz", bufLen))
+    assert(buf.equals("/foo/bar/index.html.gz"))
+
+    //test buffer overflow
+    assert(!StaticFileWeblet.appendStr(buf, "1234567890", bufLen))
+    //under this case, buf should not be modified 
+    assert(buf.equals("/foo/bar/index.html.gz"))
+  }
+
+  define int bufLen = 32 
+  inline static Str(bufLen) buf
+}

--- a/tools/wireshark/sox.lua
+++ b/tools/wireshark/sox.lua
@@ -1,3 +1,5 @@
+-- TODO: stream support 
+
 -- to survive in different version of lua, try 'bit' module first, if fails,
 -- try load 'bit32'. refers: http://lua-users.org/wiki/BitwiseOperators
 local status, bit = pcall(require, "bit")
@@ -24,8 +26,16 @@ local f_headerAck = ProtoField.uint16("dasp.ack", "ack", base.DEC)
 local f_headerAckMore = ProtoField.bytes("dasp.ackMore", "ackMore")
 local f_headerErrorCode = ProtoField.uint16("dasp.errorCode", "errorCode", base.Hex)
 
-dasp_proto.fields = {f_sessionId, f_seqNum, f_msgType, f_headerFieldNum, 
-                     f_headerAck, f_headerAckMore, f_headerErrorCode}
+-- dasp stream support 
+local f_daspFrameRequest = ProtoField.framenum("dasp.request", "request", base.NONE, frametype.REQUEST, 0) 
+local f_daspFrameRequestDup = ProtoField.framenum("dasp.requestDup", "dasp requestDup", base.NONE, frametype.REQUEST, 0) 
+local f_daspFrameRequestAck = ProtoField.framenum("dasp.requestAck", "requestAck", base.NONE, frametype.ACK, 0) 
+
+dasp_proto.fields = {
+  f_sessionId, f_seqNum, f_msgType, f_headerFieldNum, 
+  f_headerAck, f_headerAckMore, f_headerErrorCode,
+  f_daspFrameRequest, f_daspFrameRequestDup, f_daspFrameRequestAck
+}
 
 -- sox fields
 local f_soxCmd = ProtoField.string("sox.cmd", "cmd")
@@ -46,23 +56,26 @@ local f_linkFromSlotId = ProtoField.uint8("sox.linkFromSlotId", "linkFromSlotId"
 local f_linkToCompId = ProtoField.uint16("sox.linkToCompId", "linkToCompId", base.DEC)
 local f_linkToSlotId = ProtoField.uint8("sox.linkToSlotId", "linkToSlotId", base.DEC)
 
-local f_fileOpenMethod = ProtoField.string("sox.fileOpenMethod", "fileOpenMethod")
+local f_fileOpenMethod = ProtoField.stringz("sox.fileOpenMethod", "fileOpenMethod")
 local f_fileUri = ProtoField.stringz("sox.fileUri", "fileUri")
 local f_fileSize = ProtoField.uint32("sox.fileSize", "fileSize", base.DEC)
 
 local f_chunkNum = ProtoField.uint16("sox.chunkNum", "chunkNum", base.DEC)
 local f_chunkSize = ProtoField.uint16("sox.chunkSize", "chunkSize", base.DEC)
 
-local f_soxBytes = ProtoField.bytes("sox.byteVal", "bytesVal")
-local f_soxStr = ProtoField.stringz("sox.strVal", "strVal")
+local f_soxRenameFrom = ProtoField.stringz("sox.renameFrom", "renameFrom")
+local f_soxRenameTo = ProtoField.stringz("sox.renameTo", "renameTo")
 local f_soxPlatformId = ProtoField.stringz("sox.platformId", "platformId")
 local f_soxError = ProtoField.stringz("sox.errorStr", "errorStr")
+
+local f_soxBytes = ProtoField.bytes("sox.byteVal", "byteVal")
 
 sox_proto.fields = {f_soxCmd, f_soxReplyNum, f_soxCompId, f_soxSlotId, 
                     f_parentCompId, f_kitId, f_typeId, f_compName, 
                     f_compWhat, f_linkAction, f_linkFromCompId,
+                    f_fileOpenMethod, f_fileUri, f_fileSize,
                     f_linkFromSlotId, f_linkToCompId, f_linkToSlotId, f_chunkNum,
-                    f_chunkSize, f_soxBytes, f_soxStr, f_soxPlatformId, f_soxError}
+                    f_chunkSize, f_soxBytes, f_soxRenameFrom, f_soxRenameTo, f_soxPlatformId, f_soxError}
 
 local msg_types = {
   [0] = {"discover", "Discover"},
@@ -189,8 +202,8 @@ function add_whatMask(tree, buf, offset)
 end
 
 function add_file_headers(tree, buf, offset)
-  local byte = buf(offset, 1)
-  while byte ~= '\0' do 
+  local byte = buf(offset, 1):uint()
+  while byte ~= 0 do 
     local start = offset
     local name = buf(offset):stringz()
     offset = offset + string.len(name) + 1
@@ -199,7 +212,7 @@ function add_file_headers(tree, buf, offset)
     offset = offset + string.len(value) + 1
     tree:add(buf(start, offset-start), name, value)
 
-    byte = buf(offset, 1)
+    byte = buf(offset, 1):uint()
   end
   offset = offset + 1
 
@@ -207,7 +220,7 @@ function add_file_headers(tree, buf, offset)
 end
 
 function parse_comp_tree(tree, buf, offset)
-  local subtree = tree:add(f_compWhat, buf(offset, 1), buf(offset, 1):string(), "Tree")
+  local subtree = tree:add(f_compWhat, buf(offset, 1), buf(offset, 1):string(), "compTree")
   offset = offset + 1
 
   subtree:add(f_kitId, buf(offset, 1))
@@ -234,7 +247,7 @@ function parse_comp_tree(tree, buf, offset)
 end
 
 function parse_comp_links(tree, buf, offset)
-  local subtree = tree:add(f_compWhat, buf(offset, 1), buf(offset, 1):string(), "Links")
+  local subtree = tree:add(f_compWhat, buf(offset, 1), buf(offset, 1):string(), "compLink")
   offset = offset + 1
   
   local index = 1
@@ -257,12 +270,12 @@ function parse_comp_links(tree, buf, offset)
 end
 
 function parse_comp_props(tree, buf, offset)
-  local typeChar = buf(offset, 1):uint()
+  local typeChar = buf(offset, 1):string()
   local subtree = nil
-  if typeChar == 'c' or typeChar == 'C' then
-    subtree = tree:add(f_compWhat, buf(offset, 1), buf(offset, 1):string(), "Config Props")
-  elseif typeChar == 'r' or typeChar == 'R' then 
-    subtree = tree:add(f_compWhat, buf(offset, 1), buf(offset, 1):string(), "Runtime Props")
+  if typeChar == "c" or typeChar == "C" then
+    subtree = tree:add(f_compWhat, buf(offset, 1), buf(offset, 1):string(), "configProps")
+  elseif typeChar == "r" or typeChar == "R" then 
+    subtree = tree:add(f_compWhat, buf(offset, 1), buf(offset, 1):string(), "runtimeProps")
   end
   offset = offset + 1
 
@@ -293,8 +306,8 @@ local sox_handlers = {
   
   -- fileRename 
   ["b"] = function (tree, buf, offset)
-    offset = add_string(tree, f_soxStr, buf, offset)
-    offset = add_string(tree, f_soxStr, buf, offset)
+    offset = add_string(tree, f_soxRenameFrom, buf, offset)
+    offset = add_string(tree, f_soxRenameTo, buf, offset)
     return offset
   end,
   
@@ -302,9 +315,9 @@ local sox_handlers = {
   ["c"] = function (tree, buf, offset)
     offset = add_compId(tree, buf, offset)
 
+    local mapping = {t = "tree", c = "config", r = "runtime", l = "links"}
     local whatElem = tree:add(f_compWhat, buf(offset, 1))
     local whatChar = buf(offset, 1):string()
-    local mapping = {t = "tree", c = "config", r = "runtime", l = "links"}
     whatElem:append_text("(" .. mapping[whatChar] .. ")")
     offset = offset + 1
 
@@ -314,11 +327,11 @@ local sox_handlers = {
     offset = add_compId(tree, buf, offset)
     
     local compDataChar = buf(offset, 1):string()
-    if compDataChar == 't' then 
+    if compDataChar == "t" then 
       offset = parse_comp_tree(tree, buf, offset)
-    elseif compDataChar == 'l' then 
+    elseif compDataChar == "l" then 
       offset = parse_comp_links(tree, buf, offset)
-    elseif compDataChar == 'c' or compDataChar == 'r' or compDataChar == 'C' or compDataChar == 'R' then 
+    elseif compDataChar == "c" or compDataChar == "r" or compDataChar == "C" or compDataChar == "R" then 
       offset = parse_comp_props(tree, buf, offset)
     end
     return offset
@@ -335,11 +348,11 @@ local sox_handlers = {
     offset = add_compId(tree, buf, offset)
 
     local compDataChar = buf(offset, 1):string()
-    if compDataChar == 't' then 
+    if compDataChar == "t" then 
       offset = parse_comp_tree(tree, buf, offset)
-    elseif compDataChar == 'l' then 
+    elseif compDataChar == "l" then 
       offset = parse_comp_links(tree, buf, offset)
-    elseif compDataChar == 'c' or compDataChar == 'r' or compDataChar == 'C' or compDataChar == 'R' then 
+    elseif compDataChar == "c" or compDataChar == "r" or compDataChar == "C" or compDataChar == "R" then 
       offset = parse_comp_props(tree, buf, offset)
     end
     return offset
@@ -347,12 +360,10 @@ local sox_handlers = {
   
   -- fileOpen 
   ["f"] = function (tree, buf, offset)
-    tree:add(f_fileOpenMethod, buf(offset, 1)) 
-    offset = offset + 1
-    
+    offset = add_string(tree, f_fileOpenMethod, buf, offset)
     offset = add_string(tree, f_fileUri, buf, offset)
     
-    tree:add(f_fileSize, buf(offset, 4):uint())
+    tree:add(f_fileSize, buf(offset, 4))
     offset = offset + 4
     
     tree:add(buf(offset, 2), "suggestedChunkSize", buf(offset, 2):uint())
@@ -363,7 +374,7 @@ local sox_handlers = {
     return offset
   end,
   ["F"] = function (tree, buf, offset)
-    tree:add(f_fileSize, buf(offset, 4):uint())
+    tree:add(f_fileSize, buf(offset, 4))
     offset = offset + 4
     
     tree:add(buf(offset, 2), "actualChunkSize", buf(offset, 2):uint())
@@ -421,7 +432,7 @@ local sox_handlers = {
     offset = offset + 1
 
     local label = "" .. fromCompId .. "." .. fromSlotId .. " -> " .. toCompId .. "." .. toSlotId
-    if string.char(linkType:uint()) == 'a' then
+    if string.char(linkType:uint()) == "a" then
       linkTypeElem:append_text("(add link: " .. label .. ")")
     else 
       linkTypeElem:append_text("(delete link: " .. label .. ")")
@@ -605,7 +616,7 @@ function parse_sox(tree, buf, offset)
     if handler ~= nil then
       offset = handler(tree, buf, offset)
     end
-    
+
     -- output all pending bytes
     if offset < buf:len() then 
       tree:add(f_soxBytes, buf(offset))
@@ -624,9 +635,6 @@ function add_header(tree, buf, offset)
   if header_ids[headerIdVal] ~= nil then
     headerName = header_ids[headerIdVal]
   end
-  -- if header_mappings[headerVal:uint()] ~= nil then
-  --   headerName = header_mappings[headerVal:uint()]
-  -- end
 
   if headerTypeVal == 0 then 
     if headerIdVal == 0x0d then
@@ -643,7 +651,7 @@ function add_header(tree, buf, offset)
       -- GOTCHA: there is a bug in old version of sox, ackMore is set as u2,
       --         but encoded in bytes(only 1 byte). here is a workaround to
       --         make this case work
-      local elem = tree:add(f_headerAckMore, buf(offset+2, 1));
+      tree:add(f_headerAckMore, buf(offset+2, 1));
     else
       tree:add(buf(offset, 3), headerName, buf(offset+1, 2):uint())
     end
@@ -693,6 +701,9 @@ function dasp_proto.dissector(buf, pinfo, tree)
   local msgType = subtree:add(f_msgType, buf(4, 1), typeVal)
   if msg_types[typeVal] ~= nil then
     msgType:append_text(" (" .. msg_types[typeVal][1] .. ")")
+    pinfo.cols.info = string.format("seqNum: %5d msgType: %-12s %s", buf(2, 2):uint(), msg_types[typeVal][1], pinfo.cols.info)
+  else
+    pinfo.cols.info = string.format("seqNum: %5d %-12s", buf(2, 2):uint(), pinfo.cols.info)
   end
 
   local headerNum = buf(4, 1):bitfield(4, 4)


### PR DESCRIPTION
communityWebServer kit try to add the basic web server feature to sedona, it mainly focus on serve static files for now and only handle 'GET' request. For example, you can put a mirror of sedona docs under 'statics' folder within folder 'doc', then you can view the document in browser from 'http://SEDONA_IP/statics/doc'. 

It can serve a rich client web application developed by [React](https://reactjs.org/), [Vue](https://reactjs.org/) or [Angular](https://angularjs.org/) etc, and if the web application talks to our RESTful API, there will many possibilities. 