### PR TITLE
Cross-compilation support

### DIFF
--- a/adm/compilejar.py
+++ b/adm/compilejar.py
@@ -30,7 +30,8 @@ def compile(srcDir, depends, packages, jarFile, func=None):
   # compile using jikes.exe
   print "  Javac [" + srcDir + "]"
   cmd = env.jikes
-  # cmd += " +E +Pno-shadow"
+  cmd += " -source 1.6 "
+  cmd += " -target 1.6 "
   cmd += " -d " + temp
   cmd += " -classpath " + env.jreRt + env.cpSep + srcDir
   for depend in depends:

--- a/adm/makedev.py
+++ b/adm/makedev.py
@@ -62,6 +62,10 @@ def initParser():
                              default=None,
                              metavar="CC")
 
+  parser.add_argument('--sys', action='store',
+                             help='Force to use build scripts for specific platform (posix,nt)',
+                             default=os.name)
+
 # Main
 if __name__ == '__main__':
   global parser
@@ -76,6 +80,7 @@ if __name__ == '__main__':
   print 'options.run     = ', options.run
   print 'options.scode   = ', options.scode
   print 'options.app     = ', options.app
+  print 'options.sys     = ', options.sys
 
   scodefile = os.path.splitext(options.scode)[0] + '.scode'
   sabfile   = os.path.splitext(options.app)[0]   + '.sab'
@@ -121,7 +126,7 @@ if __name__ == '__main__':
     compilekit.compile(options.app)
 
   # Make Sedona VM (svm)
-  if os.name == "posix": # unix, OSX
+  if options.sys == "posix": # unix, OSX
     make = makeunixvm
   else: # win32
     make = makewinvm

--- a/adm/makedev.py
+++ b/adm/makedev.py
@@ -48,6 +48,19 @@ def initParser():
                              default=os.path.join(env.scode, defaultscode), 
                              metavar="XML")
 
+  help_msg = 'The path to the sedonaPlatform XML file. ' + \
+             'If this option is omitted, then environment variable $SVM_PLATFORM will be checked. ' + \
+             'If that variable is not set, then $sedona_home/platforms/src/generic/unix/generic-unix.xml ' + \
+             'will be used.'
+  parser.add_argument('-p', '--platform', action='store',
+                             help=help_msg,
+                             default=None,
+                             metavar="PLATFORM")
+
+  parser.add_argument('-c', '--compiler', action='store',
+                             help='Compiler to use. Defaults to gcc',
+                             default=None,
+                             metavar="CC")
 
 # Main
 if __name__ == '__main__':
@@ -114,6 +127,11 @@ if __name__ == '__main__':
     make = makewinvm
 
   args = []
+  if options.compiler is not None:
+    args += ['-c', options.compiler ]
+
+  if options.platform is not None:
+    args += ['-p', options.platform ]
 
   status = make.main(args)
   if status:

--- a/adm/makedev.py
+++ b/adm/makedev.py
@@ -38,6 +38,10 @@ def initParser():
                              help='Run specified test (default is all)',
                              default=None, choices=['sedonac', 'svm', 'all', 'none'], 
                              metavar="TEST")
+  parser.add_argument('-k', '--kits', action='store',
+                             help='Specify XML to build additional external kits. Default is None',
+                             default=None,
+                             metavar="KITS")
   parser.add_argument('-r', '--run', action='store_true', default=False,
                              help='Run an app after building')
   parser.add_argument('-a', '--app', action='store', 
@@ -77,6 +81,7 @@ if __name__ == '__main__':
   # Print options
   print 'options.version = ', options.version
   print 'options.test    = ', options.test
+  print 'options.kits    = ', options.kits
   print 'options.run     = ', options.run
   print 'options.scode   = ', options.scode
   print 'options.app     = ', options.app
@@ -117,6 +122,11 @@ if __name__ == '__main__':
   
   # Make all kits
   compilekit.compile(env.kits, ["-outDir", env.build])
+
+  # Make additional external kits
+  if options.kits is not None:
+    print "Build additional external kits"
+    compilekit.compile(options.kits)
 
   # Make windows test scode (or scode specified on cmd line)
   compilekit.compile(options.scode)

--- a/adm/makedev.py
+++ b/adm/makedev.py
@@ -109,9 +109,13 @@ if __name__ == '__main__':
 
   # Make Sedona VM (svm)
   if os.name == "posix": # unix, OSX
-    status = makeunixvm.main([])
+    make = makeunixvm
   else: # win32
-    status = makewinvm.compile()
+    make = makewinvm
+
+  args = []
+
+  status = make.main(args)
   if status:
     raise env.BuildError("FATAL: make svm failed")
 

--- a/adm/makewinvm.py
+++ b/adm/makewinvm.py
@@ -115,15 +115,13 @@ def verifyOpts():
     if not platFile:
       platFile = os.path.join(env.platforms, "src", "generic", "win32", "generic-win32.xml")
 
-
-# Main
-if __name__ == '__main__':
+def main(args):
   global parser
   config = defs
 
   # Parse command line arguments
   initParser()
-  options = parser.parse_args()
+  options = parser.parse_args(args)
 
   if (options.list_compilers):
     listCompilers()
@@ -158,4 +156,7 @@ if __name__ == '__main__':
   # Create platform archive and install in platform DB
   platArchive.main(["--db", "--stage", os.path.join(stageDir, ".par")])
 
-
+# __main__
+if __name__ == '__main__':
+  main(sys.argv[1:])
+  sys.exit()

--- a/adm/unix/compileunix.py
+++ b/adm/unix/compileunix.py
@@ -33,7 +33,10 @@ def gcc(exeFile, srcFiles, includes, libs, defs):
   if (platform.machine() == 'x86_64') and (compile_prefix is None):
     cmd += " -m32"  # always compile in 32bit mode
 
+  sysroot = os.environ.get("SVM_SYSROOT")
   for include in includes:
+    if sysroot is not None and include.startswith("/"):
+      include = sysroot + os.sep + include
     cmd += " -I" + include
 
   # defines (tuples)

--- a/adm/unix/compileunix.py
+++ b/adm/unix/compileunix.py
@@ -46,6 +46,11 @@ def gcc(exeFile, srcFiles, includes, libs, defs):
 
   cmd += " -DPLAT_BUILD_VERSION=" + '\\"' + env.buildVersion() + '\\"'
 
+  # add user CFLAGS
+  cflags = os.environ.get("SVM_CFLAGS")
+  if cflags is not None:
+    cmd += " " + cflags
+
   # src
   for src in srcFiles:
     cmd += " " + src
@@ -53,6 +58,11 @@ def gcc(exeFile, srcFiles, includes, libs, defs):
   # libs
   for lib in libs:
     cmd += " -l" + lib
+
+  # add user LDFLAGS
+  ldflags = os.environ.get("SVM_LDFLAGS")
+  if ldflags is not None:
+    cmd += " " + ldflags
 
   # remaining options
   cmd += " -O2"

--- a/adm/unix/compileunix.py
+++ b/adm/unix/compileunix.py
@@ -25,9 +25,13 @@ import fileutil
 #def compile(exeFile, srcFiles, includes, libs, defs):
 def gcc(exeFile, srcFiles, includes, libs, defs):
   # standard includes
+  compile_prefix=os.environ.get("SVM_CROSS_COMPILE")
   cmd = "gcc"
-  if (platform.machine() == 'x86_64'):
-    cmd += " -m32" # always compile in 32bit mode
+  if compile_prefix is not None:
+    cmd = compile_prefix + cmd
+
+  if (platform.machine() == 'x86_64') and (compile_prefix is None):
+    cmd += " -m32"  # always compile in 32bit mode
 
   for include in includes:
     cmd += " -I" + include

--- a/adm/unix/init.sh
+++ b/adm/unix/init.sh
@@ -36,7 +36,6 @@ done
 
 # Ensure permissions are correct for adm python scripts
 find $sedona_home/adm -name "*.py" -exec chmod 755 '{}' \; 2> /dev/null
-find $sedona_home/adm/unix -name "*.py" -exec chmod 755 '{}' \; 2> /dev/null
 find $sedona_home/adm -name "*.sh" -exec chmod 755 '{}' \; 2> /dev/null
 find $sedona_home/bin -name "*.sh" -exec chmod 755 '{}' \; 2> /dev/null
 

--- a/src/kits/inet/native/std/inet_util_std.h
+++ b/src/kits/inet/native/std/inet_util_std.h
@@ -91,6 +91,8 @@ typedef int socket_t;
 #ifdef __UNIX__
 
 #include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #include <sys/ioctl.h>
 #include <netdb.h>
 #include <errno.h>


### PR DESCRIPTION
This set of changes allows to cross-compile sedona to new target platform and add new kits with even native methods without any changes to upstream platform. It's possible to overwrite even existing kits by own version.

For example, following directory structure exists:

```
<some dir>
    upstream-sedona
        adm
        apps
        bin
        build
        ...
        src
        tools

    new-target-platform
        apps
            defaultApp.sax
        platforms
            db
            src
                generic
                    unix
                        generic-unix.xml
                        ...
        scode
            defaultKits.xml
        src
            kits
                newKit
                newNativeKit
                serial
                sys
                dir.xml
```
                
Following commands allows to build sedona for new target platform
```
$ export SVM_CFLAGS=-DFANCY_FEATURE_EN=1
$ export SVM_LDFLAGS='-lm -pthread'
$ export SVM_CROSS_COMPILE=arm-linux-gnueabihf-
$ upstream-sedona/adm/makedev.py -t none -p new-target-platform/platforms/src/generic/unix/generic-unix.xml -k new-target-platform/src/kits/dir.xml -s new-target-platform/scode/defaultKits.xml -a new-target-platform/apps/defaultApp.sax
```
There are some things that have to be done to make this directory structure to work. Most of them covers usage of relative paths to source files.

1.  In platform description 'generic-unix.xml' paths to source code for native kits should be given relative to 'upstream-sedona' directory.

```
<sedonaPlatform...
    ...
    <nativeSource path="/src/kits/inet/native/sha1" />
    <nativeSource path="/src/kits/datetimeStd/native/std" />
    
    <nativeSource path="/../new-target-platform/src/kits/serial/native/linux" />
    <nativeSource path="/../new-target-platform/src/kits/serial/native" />
    ...
</sedonaPlatform>
```

2.  To build external kits new '-k' option of makedev.py is used. It points to XML with description of all additional kits, including platform kit.  

```
<sedonaDir>
     <!-- overwritten kits -->
     <target name="sys"/>
     <target name="serial" />

     <!-- new kits -->
     <target name="newKit" />
     <target name="newNativeKit" />

     <!-- platform kits -->
     <target name="../../platforms/src/generic/unix" />

</sedonaDir>
```


All build results are located in 'upstream-sedona/build' and 'upstream-sedona/bin' directories and with external shell scripts it's possible to do with results whatever is needed: build release support package, move to place for firmware generation, run built runtime on development machine and so on.