### PR TITLE
improve web kit to be more stable (#27)

### DIFF
--- a/src/kits/inet/native/std/inet_TcpServerSocket_std.c
+++ b/src/kits/inet/native/std/inet_TcpServerSocket_std.c
@@ -107,6 +107,16 @@ Cell inet_TcpServerSocket_accept(SedonaVM* vm, Cell* params)
     return falseCell;
   }
 
+#ifdef SO_NOSIGPIPE
+  int val = 1;
+  if (setsockopt(acceptedSock, SOL_SOCKET, SO_NOSIGPIPE, 
+              (void*)&val, sizeof(val)) != 0)
+  {
+    closesocket(acceptedSock);
+    return falseCell;
+  }
+#endif
+
   // mark as open
   setSocket(accepted, acceptedSock);
   setClosed(accepted, 0);

--- a/src/kits/inet/native/std/inet_TcpSocket_std.c
+++ b/src/kits/inet/native/std/inet_TcpSocket_std.c
@@ -176,6 +176,9 @@ Cell inet_TcpSocket_write(SedonaVM* vm, Cell* params)
   Cell result;
 
   buf = buf + off;
+  //NOTE: MSG_NOSIGNAL is not defined under macOS(BSD like
+  //      system?), should use `setsockopt` to set 
+  //      SO_NOSIGPIPE after socket is created
   result.ival = send(sock, buf, len, MSG_NOSIGNAL);
   if (result.ival >= 0) return result;  // 0+ is ok
   if (inet_errorIsWouldBlock()) return zeroCell;

--- a/src/kits/web/Handler.sedona
+++ b/src/kits/web/Handler.sedona
@@ -74,10 +74,16 @@ internal class Handler
 
     // read request bytes
     int read = socket.read(buf, pos, bufLen)
-    if (read <= 0) 
+
+    if (read == 0) // no data available yet (nonblocking)
+      return true
+    else if (read < 0) // some error happened
     { 
-      res.writeStatus(HttpCode.badRequest).finishHeaders().close()
-      return true 
+      if (socket.isClosed())
+        WebService.log.trace("socket has been closed, skip request handling")
+      else
+        res.writeStatus(HttpCode.badRequest).finishHeaders().close()
+      return false 
     }
 
     // update read offset


### PR DESCRIPTION
after I made the following changes, I can not reproduce the 'ERR_CONNECTION_RESET' issue in browser anymore, and the ab benchmark testing looks good, too. 

Here is one session of ab benchmark on my macbook: 
```
$ ab -r -t 30 -c 4 http://localhost:8080/spy
This is ApacheBench, Version 2.3 <$Revision: 1826891 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 5000 requests
Completed 10000 requests
Completed 15000 requests
Finished 16315 requests

Server Software:
Server Hostname:        localhost
Server Port:            8080

Document Path:          /spy
Document Length:        1048 bytes

Concurrency Level:      4
Time taken for tests:   36.182 seconds
Complete requests:      16315
Failed requests:        8
   (Connect: 2, Receive: 3, Length: 3, Exceptions: 0)
Total transferred:      17829016 bytes
HTML transferred:       17094976 bytes
Requests per second:    450.91 [#/sec] (mean)
Time per request:       8.871 [ms] (mean)
Time per request:       2.218 [ms] (mean, across all concurrent requests)
Transfer rate:          481.20 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   5.2      0     106
Processing:     0    5 287.6      2   25961
Waiting:        0    2  11.1      2     712
Total:          0    6 287.7      2   25961

Percentage of the requests served within a certain time (ms)
  50%      2
  66%      2
  75%      2
  80%      2
  90%      2
  95%      2
  98%      3
  99%      3
 100%  25961 (longest request)
```

Changes:
* when data is not available on nonblocking socket, retry it later
* disable SIGPIPE on web server's socket, this prevents svm crashing under high traffic load